### PR TITLE
fix that the coupons tab doesn't stop loading

### DIFF
--- a/app/pages/coupons/index.js
+++ b/app/pages/coupons/index.js
@@ -30,10 +30,16 @@ function txToDecrypted(tx) {
 
     let encrypted_coupon = tx.outs[n].scriptPubKey.hex.slice(4)
     // pubkey/privkey of address where the transaction was sent
-    let pair = wallet.getPrivateKeyForAddress(tx.outs[0].address)
+    let string
+    try {
+        let pair = wallet.getPrivateKeyForAddress(tx.outs[0].address)
+        let dec = jeeq.decryptMessage(pair.d, pair.getPublicKeyBuffer(), Buffer.from(encrypted_coupon, 'hex'))
+        string = new TextDecoder().decode(dec);
+    } catch (error) {
+        console.log(error)
+        string = "privkey not found"
+    }
 
-    var dec = jeeq.decryptMessage(pair.d, pair.getPublicKeyBuffer(), Buffer.from(encrypted_coupon, 'hex'))
-    var string = new TextDecoder().decode(dec);
     return {coupon: string, timestamp: tx.timestamp, confirmations: tx.confirmations};
 }
 


### PR DESCRIPTION
catch an exception that otherwise results in a constant "loading coupons" message in the coupons tab